### PR TITLE
ポケモン名を標準で表示するようにした

### DIFF
--- a/app/components/pokemon-quiz.tsx
+++ b/app/components/pokemon-quiz.tsx
@@ -185,7 +185,7 @@ export const PokemonQuiz: React.FC = () => {
       <Card className="mb-4">
         <CardHeader>
           <CardTitle className="flex justify-between items-center">
-            <span>{currentPokemon.name.en} {showJapanese && `(${currentPokemon.name.jp})`}</span>
+            <span>{currentPokemon.name.en} {`(${currentPokemon.name.jp})`}</span>
             <Button
               variant="ghost"
               size="icon"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ポケモンの日本語名を常に表示するように変更しました。英語名とともに日本語名が括弧内に表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->