### PR TITLE
Fix Node.js version format for Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {
-    "node": "18.20.4"
+    "node": "18.x"
   }
 }


### PR DESCRIPTION
Vercelのデプロイエラーを解決するため、package.jsonのNode.jsバージョン指定を修正しました。特定のバージョン（18.20.4）からメジャーバージョンのみの形式（18.x）に変更し、Vercelのデプロイ要件に適合させています。

## 修正内容
- package.jsonの \ セクションを修正
  - 変更前: \
  - 変更後: \

## 期待される結果
- Vercelへのデプロイが正常に完了すること
- npm installでのエンジン互換性警告が解消されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Node.js のバージョン指定を柔軟な "18.x" に変更し、バージョン18系全体で動作可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->